### PR TITLE
Feature/merge trajectories

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "NamedTrajectories"
 uuid = "538bc3a1-5ab9-4fc3-b776-35ca1e893e08"
 authors = ["Aaron Trowbridge <aaron.j.trowbridge@gmail.com> and contributors"]
-version = "0.2.3"
+version = "0.2.4"
 
 [deps]
 CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"

--- a/src/struct_named_trajectory.jl
+++ b/src/struct_named_trajectory.jl
@@ -489,6 +489,7 @@ function NamedTrajectory(
         <:Tuple{Vararg{AbstractMatrix{R}}}
     } where names,
     traj::NamedTrajectory;
+    new_timestep::Union{Nothing, R}=nothing,
     new_control_names::Tuple{Vararg{Symbol}}=()
 ) where R <: Real
     @assert all([k ∈ traj.names for k ∈ keys(comps)])
@@ -499,6 +500,10 @@ function NamedTrajectory(
     )
     @assert !isempty(control_names) "must specify at least one control"
 
+    if traj.timestep isa Symbol && isnothing(new_timestep)
+        @assert traj.timestep ∈ keys(comps) "timestep symbol must be in components"
+    end
+
     bounds = NamedTuple([(k => traj.bounds[k]) for k ∈ keys(comps) if k ∈ keys(traj.bounds)])
     initial = NamedTuple([(k => traj.initial[k]) for k ∈ keys(comps) if k ∈ keys(traj.initial)])
     final = NamedTuple([(k => traj.final[k]) for k ∈ keys(comps) if k ∈ keys(traj.final)])
@@ -508,7 +513,7 @@ function NamedTrajectory(
     return NamedTrajectory(
         comps;
         controls=control_names,
-        timestep=traj.timestep,
+        timestep=isnothing(new_timestep) ? traj.timestep : new_timestep,
         bounds=bounds,
         initial=initial,
         final=final,

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -20,3 +20,71 @@ function get_fixed_time_traj2(;
     fixed_time_data = (x = rand(x_dim, T), y_dim = rand(y_dim, T), u = rand(a_dim, T))
     return NamedTrajectory(fixed_time_data; timestep=Δt, controls=:u)
 end
+
+function named_trajectory_type_1(; free_time=false)
+    # Hadamard gate, two dda controls (random), Δt = 0.2
+    data = [
+        1.0          0.957107     0.853553     0.75         0.707107;
+        0.0          0.103553     0.353553     0.603553     0.707107;
+        0.0          0.103553     0.146447     0.103553     1.38778e-17;
+        0.0         -0.25        -0.353553    -0.25        -1.52656e-16;
+        0.0          0.103553     0.353553     0.603553     0.707107;
+        1.0          0.75         0.146447    -0.457107    -0.707107;
+        0.0         -0.25        -0.353553    -0.25        -1.249e-16;
+        0.0          0.603553     0.853553     0.603553     4.16334e-16;
+        0.0         -0.243953     0.959151    -0.665253     0.0;
+        0.0          0.0139165    0.668917     0.625329     0.0;
+        0.00393491   0.0240775   -0.00942396   0.00329391   0.00941354;
+       -0.00223794  -0.0105816    0.00328457   0.0204239    0.0253415;
+        0.0058186    0.00686586  -0.00422555   0.00442631   0.000319156;
+       -0.00134597  -0.00120682   0.0114915    0.00189333  -0.0251649;
+        0.2          0.2          0.2          0.2          0.2
+    ]
+
+    if free_time
+        components = (
+            Ũ⃗ = data[1:8, :],
+            a = data[9:10, :],
+            da = data[11:12, :],
+            dda = data[13:14, :],
+            Δt = data[15:15, :]
+        )
+        controls = (:dda, :Δt)
+        timestep = :Δt
+        bounds = (
+            a = ([-1.0, -1.0], [1.0, 1.0]), 
+            dda = ([-1.0, -1.0], [1.0, 1.0]), 
+            Δt = ([0.1], [0.30000000000000004])
+        )
+    else 
+        components = (
+            Ũ⃗ = data[1:8, :],
+            a = data[9:10, :],
+            da = data[11:12, :],
+            dda = data[13:14, :]
+        )
+        controls = (:dda,)
+        timestep = 0.2
+        bounds = (
+            a = ([-1.0, -1.0], [1.0, 1.0]), 
+            dda = ([-1.0, -1.0], [1.0, 1.0]), 
+        )
+    end
+
+    initial = (
+        Ũ⃗ = [1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0],
+        a = [0.0, 0.0]
+    )
+    final = (a = [0.0, 0.0],)
+    goal = (Ũ⃗ = [0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0],)
+
+    return NamedTrajectory(
+        components;
+        controls=controls,
+        timestep=timestep,
+        bounds=bounds,
+        initial=initial,
+        final=final,
+        goal=goal
+    )
+end


### PR DESCRIPTION
Move trajectory merging from QuantumCollocation direct_sums into NamedTrajectories.

This will help with initialization (currently, there is no well-defined choice for what to batch on in initialization). This will allow for trajectory initialization routines to initialize single trajectory objects, which can be merged after the fact).