### PR TITLE
Make plotting functionality an extension package

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,13 +1,11 @@
 name = "NamedTrajectories"
 uuid = "538bc3a1-5ab9-4fc3-b776-35ca1e893e08"
 authors = ["Aaron Trowbridge <aaron.j.trowbridge@gmail.com> and contributors"]
-version = "0.2.6"
+version = "0.3.0"
 
 [deps]
-CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
 JLD2 = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
 LaTeXStrings = "b964fa9f-0449-5b57-a5c2-d3ea65f4040f"
-Latexify = "23fbe1c1-3f47-55db-b15f-69d7ec21a316"
 OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
@@ -15,11 +13,16 @@ TestItemRunner = "f8b46487-2199-4994-9208-9a1283c18c0a"
 TestItems = "1c621080-faea-4a02-84b6-bbd5e436b8fe"
 Unidecode = "967fb449-e509-55aa-8007-234b4096b967"
 
+[weakdeps]
+CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
+
+[extensions]
+NamedTrajectoryCairoMakieExt = ["CairoMakie"]
+
 [compat]
 CairoMakie = "0.13"
 JLD2 = "0.5"
 LaTeXStrings = "1.4"
-Latexify = "0.16"
 OrderedCollections = "1.7"
 Reexport = "1.2"
 TestItemRunner = "1.0"
@@ -31,4 +34,4 @@ julia = "1.10, 1.11"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["Test", "CairoMakie"]

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,4 +1,5 @@
 [deps]
+CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 Literate = "98b081ad-f1c9-55d3-8b20-4c87d4299306"
 LiveServer = "16fef848-5104-11e9-1b77-fb7a48bbb589"

--- a/docs/literate/plotting.jl
+++ b/docs/literate/plotting.jl
@@ -6,16 +6,6 @@
 
 # Visualizing trajectories is crucial for understanding the solutions of trajectory optmization problems and `NamedTrajectories` exports a `plot` function that contains a lot of functionality that is continually being added to. [Makie.jl](https://docs.makie.org/stable/) is used as the plotting framework, and at the moment the default backend is `CairoMakie`, as it creates high quality vector graphics. The function is called as follows:
 
-#=
-```@docs
-NamedTrajectories.plot(
-    ::NamedTrajectory,
-    ::Union{Symbol, Vector{Symbol}, Tuple{Vararg{Symbol}}} = traj.names;
-    kwargs...
-)
-```
-=#
-
 # ## Basic example
 
 # Let's first create a simple trajectory to plot

--- a/docs/literate/plotting.jl
+++ b/docs/literate/plotting.jl
@@ -55,13 +55,14 @@ traj = NamedTrajectory(
 )
 
 ## plot the trajectory
-plot(traj)
+using CairoMakie
+NamedTrajectories.plot(traj)
 
 # ## Selectively plotting components
 
 # We can selectively plot components of the trajectory by passing a `Vector` of `Symbol`s to the `components` keyword argument. For example, if we only wanted to plot the state and the first control we could do the following:
-
-plot(traj, [:x, :u])
+using CairoMakie
+NamedTrajectories.plot(traj, [:x, :u])
 
 # ## Playing with transformations
 
@@ -73,7 +74,8 @@ transformations = OrderedDict(
     :x => x -> abs.(x),
 )
 
-plot(traj, [:x]; transformations=transformations)
+using CairoMakie
+NamedTrajectories.plot(traj, [:x]; transformations=transformations)
 
 # We can also pass multiple transformations to the same component, with selective labels and titles:
 
@@ -102,7 +104,8 @@ transformation_titles = OrderedDict(
 )
 
 ## plot the trajectory, with only the transformation and the `u` control
-plot(traj, [:u];
+using CairoMakie
+NamedTrajectories.plot(traj, [:u];
     transformations=transformations,
     transformation_labels=transformation_labels,
     include_transformation_labels=[[true, true]],

--- a/docs/literate/quickstart.jl
+++ b/docs/literate/quickstart.jl
@@ -49,8 +49,8 @@ traj = NamedTrajectory(data; timestep=timestep, controls=control)
 traj.names
 
 # Let's plot this trajectory
-
-plot(traj)
+using CairoMakie
+NamedTrajectories.plot(traj)
 
 
 # ## Creating a variable-timestep `NamedTrajectory`

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,47 +1,55 @@
 ```@raw html
 <div align="center">
-
-<a href="https://github.com/kestrelquantum/Piccolo.jl">
-  <img src="assets/logo.svg" alt="logo" width="25%"/>
-</a> 
-
-<div style="display: table; width: 100%;">
-  <div style="display: table-row;">
-    <div style="display: table-cell; text-align: center;"><b>Documentation</b></div>
-    <div style="display: table-cell; text-align: center;"><b>Build Status</b></div>
-    <div style="display: table-cell; text-align: center;"><b>Support</b></div>
-  </div>
-  <div style="display: table-row;">
-    <div style="display: table-cell; text-align: center;">
-      <a href="https://kestrelquantum.github.io/NamedTrajectories.jl/stable/">
-        <img src="https://img.shields.io/badge/docs-stable-blue.svg" alt="Stable"/>
-      </a>
-      <a href="https://kestrelquantum.github.io/NamedTrajectories.jl/dev/">
-        <img src="https://img.shields.io/badge/docs-dev-blue.svg" alt="Dev"/>
-      </a>
-    </div>
-    <div style="display: table-cell; text-align: center;">
-      <a href="https://github.com/kestrelquantum/NamedTrajectories.jl/actions/workflows/CI.yml?query=branch%3Amain">
-        <img src="https://github.com/kestrelquantum/NamedTrajectories.jl/actions/workflows/CI.yml/badge.svg?branch=main" alt="Build Status"/>
-      </a>
-      <a href="https://codecov.io/gh/kestrelquantum/NamedTrajectories.jl">
-        <img src="https://codecov.io/gh/kestrelquantum/NamedTrajectories.jl/branch/main/graph/badge.svg" alt="Coverage"/>
-      </a>
-    </div>
-    <div style="display: table-cell; text-align: center;">
-      <a href="https://unitary.fund">
-        <img src="https://img.shields.io/badge/Supported%20By-Unitary%20Fund-FFFF00.svg" alt="Unitary Fund"/>
-      </a>
-    </div>
-  </div>
+  <a href="https://github.com/kestrelquantum/Piccolo.jl">
+    <img src="assets/logo.svg" alt="logo" width="25%"/>
+  </a> 
 </div>
 
-<br>
-<i>An elegant way to handle messy trajectory data</i>
-<br>
-
+<div align="center">
+  <table>
+    <tr>
+      <td align="center">
+        <b>Documentation</b>
+        <br>
+        <a href="https://kestrelquantum.github.io/NamedTrajectories.jl/stable/">
+          <img src="https://img.shields.io/badge/docs-stable-blue.svg" alt="Stable"/>
+        </a>
+        <a href="https://kestrelquantum.github.io/NamedTrajectories.jl/dev/">
+          <img src="https://img.shields.io/badge/docs-dev-blue.svg" alt="Dev"/>
+        </a>
+      </td>
+      <td align="center">
+        <b>Build Status</b>
+        <br>
+        <a href="https://github.com/kestrelquantum/NamedTrajectories.jl/actions/workflows/CI.yml?query=branch%3Amain">
+          <img src="https://github.com/kestrelquantum/NamedTrajectories.jl/actions/workflows/CI.yml/badge.svg?branch=main" alt="Build Status"/>
+        </a>
+        <a href="https://codecov.io/gh/kestrelquantum/NamedTrajectories.jl">
+          <img src="https://codecov.io/gh/kestrelquantum/NamedTrajectories.jl/branch/main/graph/badge.svg" alt="Coverage"/>
+        </a>
+      </td>
+      <td align="center">
+        <b>License</b>
+        <br>
+        <a href="https://opensource.org/licenses/MIT">
+          <img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="MIT License"/>
+        </a>
+      </td>
+      <td align="center">
+        <b>Support</b>
+        <br>
+        <a href="https://unitary.fund">
+          <img src="https://img.shields.io/badge/Supported%20By-Unitary%20Fund-FFFF00.svg" alt="Unitary Fund"/>
+        </a>
+      </td>
+    </tr>
+  </table>
 </div>
 
+<div align="center">
+  <i>An elegant way to handle messy trajectory data</i>
+  <br>
+</div>
 ```
 
 # NamedTrajectories.jl

--- a/ext/NamedTrajectoryCairoMakieExt.jl
+++ b/ext/NamedTrajectoryCairoMakieExt.jl
@@ -1,0 +1,456 @@
+module NamedTrajectoryCairoMakieExt
+
+import CairoMakie: plot
+
+using OrderedCollections
+using NamedTrajectories
+using CairoMakie
+using TestItems
+
+"""
+    plot(traj::NamedTrajectory, comps=traj.names; kwargs...)
+
+Plot a `NamedTrajectory` using `CairoMakie`.
+
+# Arguments
+- `traj::NamedTrajectory`: the trajectory to plot
+- `comps::Union{Symbol, Vector{Symbol}, Tuple{Vararg{Symbol}}}`: the components of the trajectory to plot, e.g., `:x`, `[:x, :u]`, or `(:x, :u)`.
+
+# Keyword Arguments
+
+## component specification
+- `ignored_labels::Union{Symbol, Vector{Symbol}, Tuple{Vararg{Symbol}}}`: the components of the trajectory to ignore. The default is `()`.
+- `ignore_timestep::Bool`: whether or not to ignore the timestep component of the trajectory. The default is `true`.
+
+## transformations
+- `transformations::OrderedDict{Symbol, <:Union{Function, Vector}}`: a dictionary of transformations to apply to the components of the trajectory. The keys of the dictionary are the components of the trajectory to transform, and the values are either a single function or a vector of functions to apply to each column of the component. If a single function is provided, it is applied to each column of the component. If a vector of functions is provided, a separate plot is created for each function. The default is an empty `OrderedDict`.
+- `transformation_labels::Union{Nothing, OrderedDict{Symbol, <:Union{Nothing, <:AbstractString, Vector{<:Union{Nothing, <:AbstractString}}}}}`: a dictionary of labels for the transformed components of the trajectory. The keys of the dictionary are the components of the trajectory to transform, and the values are either a single string or a vector of strings that correspond to a vector of transformations. If a single string is provided, it is applied to each transformation of the component. If a vector of strings is provided, a separate label is created for each function. The default is `nothing`.
+- `include_transformation_labels::Union{Bool, Vector{<:Union{Bool, Vector{Bool}}}}`: a boolean, vector of booleans, or vector of vectors of booleans, that determines whether or not to include the labels for the transformed components of the trajectory. The default is `false`.
+- `transformation_titles::Union{Nothing, OrderedDict{Symbol, <:Union{<:AbstractString, Vector{String}}}}`: a dictionary of titles for the transformed components of the trajectory. The keys of the dictionary are the components of the trajectory to transform, and the values are either a single string or a vector of strings that correspond to a vector of transformations. If a single string is provided, it is applied to each transformation of the component. If a vector of strings is provided, a separate title is created for each function. The default is `nothing`.
+
+## style
+- `fig_size::Tuple{Int, Int}`: the size of the figure, `(width, height)`. The default is `(1200, 800)`.
+- `titlesize::Int`: the size of the titles. The default is `25`.
+- `series_color::Symbol`: the color of the series. The default is `:glasbey_bw_minc_20_n256`. See options [here](https://docs.makie.org/stable/explanations/colors/index.html#colormaps)
+- `markersize`: the size of the markers. The default is `5`.
+
+## other
+- `kwargs...`: keyword arguments passed to [`CairoMakie.series!`](https://docs.makie.org/stable/reference/plots/series/).
+"""
+function NamedTrajectories.plot(
+    traj::NamedTrajectory,
+    comps::Union{Symbol, Vector{Symbol}, Tuple{Vararg{Symbol}}} = traj.names;
+
+    # ---------------------------------------------------------------------------
+    # component specification keyword arguments
+    # ---------------------------------------------------------------------------
+
+    ignored_labels::Union{Symbol, Vector{Symbol}, Tuple{Vararg{Symbol}}}=(),
+    ignore_timestep::Bool=true,
+    merge_components::Bool=false,
+    use_latex::Bool=true,
+
+    # ---------------------------------------------------------------------------
+    # transformation keyword arguments
+    # ---------------------------------------------------------------------------
+
+    # transformations
+    transformations::OrderedDict{Symbol, <:Union{Function, Vector}} =
+        OrderedDict{Symbol, Union{Function, Vector{Function}}}(),
+
+    # labels for transformed components
+    transformation_labels::Union{
+        Nothing,
+        OrderedDict{
+            Symbol,
+            <:Union{
+                Nothing,
+                String,
+                Vector{<:Union{Nothing, <:AbstractString}}
+            }
+        }
+    } = OrderedDict{Symbol, Union{Nothing, Vector{Nothing}}}(name => f isa Vector ? fill(nothing, length(f)) : nothing for (name, f) ∈ transformations),
+
+    # whether or not to include labels for transformed components
+    include_transformation_labels::Union{
+        Bool,
+        Vector{<:Union{Bool, <:AbstractVector{Bool}}}
+    } = false,
+
+    # titles for transformations
+    transformation_titles::Union{
+        Nothing,
+        OrderedDict{Symbol, <:Union{<:AbstractString, <:AbstractVector{<:AbstractString}}}
+    } = nothing,
+
+    # ---------------------------------------------------------------------------
+    # style keyword arguments
+    # ---------------------------------------------------------------------------
+
+    fig_size::Tuple{Int, Int}=(1200, 800),
+    titlesize::Int=25,
+    markersize=5,
+    series_color::Symbol=:glasbey_bw_minc_20_n256,
+    xlims::Union{Nothing, Tuple{Real, Real}}=nothing,
+    ylims::Union{Nothing, NamedTuple, Tuple{Real, Real}}=nothing,
+
+    # ---------------------------------------------------------------------------
+    # CairoMakie.series! keyword arguments
+    # ---------------------------------------------------------------------------
+    kwargs...
+)
+    # set up parse function
+    parse = use_latex ? latexstring : string
+
+    # convert single symbol to vector: comps
+    if comps isa Symbol
+        comps = [comps]
+    end
+
+    # if transformations is only a bool, convert to vector of bools
+    if include_transformation_labels isa Bool
+        include_transformation_labels = fill(
+            include_transformation_labels,
+            length(transformations)
+        )
+    end
+
+    @assert length(include_transformation_labels) == length(transformations)
+
+    include_transformation_labels = Any[include_transformation_labels...]
+
+    for (i, (b, f)) ∈ enumerate(zip(
+        include_transformation_labels,
+        values(transformations)
+    ))
+        if f isa Function
+            @assert b isa Bool
+        else
+            if b isa Bool
+                include_transformation_labels[i] = fill(b, length(f))
+            else
+                @assert length(b) == length(f)
+            end
+        end
+    end
+
+    # convert single symbol to iterable: ignored labels
+    if ignored_labels isa Symbol
+        ignored_labels = Symbol[ignored_labels]
+    elseif ignored_labels isa Tuple
+        ignored_labels = Symbol[ignored_labels...]
+    end
+
+    @assert all([key ∈ keys(traj.components) for key ∈ comps])
+    @assert all([key ∈ keys(traj.components) for key ∈ keys(transformations)])
+
+    ts = get_times(traj)
+
+    # create figure
+    fig = Figure(size=fig_size)
+
+    # initialize axis count
+    ax_count = 0
+
+    # plot transformed components
+    for ((name, f), include_transformation_labels_k) ∈ zip(
+        transformations,
+        include_transformation_labels
+    )
+        if f isa Vector
+
+            @assert all([fⱼ isa Function for fⱼ in f])
+
+            for (j, fⱼ) in enumerate(f)
+
+                # data matrix for name component of trajectory
+                data = traj[name]
+
+                # apply transformation fⱼ to each column of data
+                transformed_data = mapslices(fⱼ, data; dims=1)
+
+                # ylims
+                if ylims isa NamedTuple
+                    if haskey(ylims, name)
+                        ylims_name = ylims[name]
+                    else
+                        ylims_name = (nothing, nothing)
+                    end
+                else
+                    ylims_name = ylims
+                end
+
+                if isnothing(transformation_titles)
+                    title = parse(name, "(t)", "\\text{ transformation } $j")
+                else
+                    title = transformation_titles[name][j]
+                end
+
+                # create axis for transformed data
+                ax = Axis(
+                    fig[ax_count + 1, 1];
+                    title=title,
+                    titlesize=titlesize,
+                    xlabel=L"t",
+                    limits =(xlims, ylims_name)
+                )
+
+                # plot transformed data
+                if include_transformation_labels_k[j]
+
+                    if isnothing(transformation_labels[name][j])
+                        labels = string.(1:size(transformed_data, 2))
+                    else
+                        labels = [
+                            parse(transformation_labels[name][j], "_{$i}")
+                                for i = 1:size(transformed_data, 2)
+                        ]
+                    end
+
+                    series!(
+                        ax,
+                        ts,
+                        transformed_data;
+                        color=series_color,
+                        markersize=markersize,
+                        labels=labels
+                    )
+                    # create legend
+                    Legend(fig[ax_count + 1, 2], ax)
+                else
+                    series!(
+                        ax,
+                        ts,
+                        transformed_data;
+                        color=series_color,
+                        markersize=markersize
+                    )
+                end
+
+                # increment axis count
+                ax_count += 1
+            end
+        else
+
+            # data matrix for name componenent of trajectory
+            data = traj[name]
+
+            # apply transformation f to each column of data
+            transformed_data = mapslices(f, data; dims=1)
+
+            if isnothing(transformation_titles)
+                title = parse(name, "(t)", "\\text{ transformation}")
+            else
+                if isnothing(transformation_titles[name])
+                    title = parse(name, "(t)", "\\text{ transformation}")
+                else
+                    title = transformation_titles[name]
+                end
+            end
+
+            # ylims
+            if ylims isa NamedTuple
+                if haskey(ylims, name)
+                    ylims_name = ylims[name]
+                else
+                    ylims_name = (nothing, nothing)
+                end
+            else
+                ylims_name = ylims
+            end
+
+            if isnothing(transformation_titles)
+                title = parse(name, "(t)", "\\text{ transformation}")
+            else
+                title = transformation_titles[name]
+            end
+
+            # create axis for transformed data
+            ax = Axis(
+                fig[ax_count + 1, :];
+                title=title,
+                titlesize=titlesize,
+                xlabel=L"t",
+                limits=(xlims, ylims_name)
+            )
+
+            # plot transformed data
+            if include_transformation_labels_k
+
+                if isnothing(transformation_labels[name])
+                    labels = [
+                        parse(name, "_{$i}")
+                            for i = 1:size(transformed_data, 2)
+                    ]
+                else
+                    labels = [
+                        parse(transformation_labels[name], "_{$i}")
+                            for i = 1:size(transformed_data, 2)
+                    ]
+                end
+
+                series!(
+                    ax,
+                    ts,
+                    transformed_data;
+                    color=series_color,
+                    markersize=markersize,
+                    labels=labels
+                )
+                # create legend
+                Legend(fig[ax_count + 1, 2], ax)
+            else
+                series!(
+                    ax,
+                    ts,
+                    transformed_data;
+                    color=series_color,
+                    markersize=markersize,
+                    kwargs...
+                )
+            end
+
+            # increment axis count
+            ax_count += 1
+        end
+    end
+    
+    # create shared axis for data
+    if merge_components
+        # ylims
+        if ylims isa NamedTuple
+            throw(ArgumentError("plot_ylims must be a tuple if merge_components is true"))
+        end
+        ax = Axis(
+            fig[ax_count + 1, 1];
+            title=parse("Trajectory"),
+            titlesize=titlesize,
+            xlabel=L"t",
+            limits=(xlims, ylims)
+        )
+    end
+
+    # plot normal components
+    for (i, name) in enumerate(comps)
+
+        if traj.timestep isa Symbol && name == traj.timestep && ignore_timestep
+            continue
+        end
+
+        # data matrix for name componenent of trajectory
+        data = traj[name]
+        
+        # create axis for data
+        if !merge_components
+            # ylims
+            if ylims isa NamedTuple
+                if haskey(ylims, name)
+                    ylims_name = ylims[name]
+                else
+                    ylims_name = (nothing, nothing)
+                end
+            else
+                ylims_name = ylims
+            end
+            
+            ax = Axis(
+                fig[ax_count + 1, 1];
+                title=parse(name, "(t)"),
+                titlesize=titlesize,
+                xlabel=L"t",
+                limits =(xlims, ylims_name)
+            )
+        end
+
+        # create labels if name is not in ignored_labels
+        if name ∈ ignored_labels
+            labels = nothing
+        else
+            labels = [parse(name, "_{$i}") for i = 1:size(data, 1)]
+        end
+
+        # plot data
+        series!(
+            ax,
+            ts,
+            data;
+            color=series_color,
+            markersize=markersize,
+            labels=labels,
+            kwargs...
+        )
+
+        # create legend
+        if name ∉ ignored_labels
+            Legend(fig[ax_count + 1, 2], ax)
+        end
+
+        # increment axis count
+        if !merge_components
+            ax_count += 1
+        end
+    end
+
+    return fig
+end
+
+function NamedTrajectories.plot(path::String, traj::NamedTrajectory, comps=traj.names; kwargs...)
+    if !isdir(dirname(path))
+        mkdir(dirname(path))
+    end
+    save(path, NamedTrajectories.plot(traj, comps; kwargs...))
+end
+
+
+### Test utils only used for the plotting functionality
+
+@testsnippet FixedTimeUtil begin
+    function get_fixed_time_traj2(;
+        T::Int=5, 
+        Δt::Float64=0.1, 
+        x_dim::Int=3, 
+        y_dim=3, 
+        a_dim::Int=2,
+        kwargs...
+    )
+        fixed_time_data = (x = rand(x_dim, T), y_dim = rand(y_dim, T), u = rand(a_dim, T))
+        return NamedTrajectory(fixed_time_data; timestep=Δt, controls=:u, kwargs...)
+    end
+end
+
+# =========================================================================== #
+
+@testitem "save plotting" default_imports=false begin
+    using CairoMakie, NamedTrajectories, Test
+    plot_path = joinpath(@__DIR__, "test.pdf")
+
+    traj = rand(NamedTrajectory, 5)
+
+    NamedTrajectories.plot(plot_path, traj)
+
+    @test isfile(plot_path)
+
+    rm(plot_path)
+end
+
+@testitem "xlim and ylim" default_imports=false setup=[FixedTimeUtil] begin
+    using CairoMakie, NamedTrajectories, Test
+    include("../test/test_utils.jl")
+    
+    # has x and y
+    traj = get_fixed_time_traj2()
+    @test NamedTrajectories.plot(traj, xlims=(0, 5)) isa Figure
+    @test NamedTrajectories.plot(traj, ylims=(x=(0, 5))) isa Figure
+    @test NamedTrajectories.plot(traj, ylims=(x=(0, 5), y=(0, 5))) isa Figure
+    @test NamedTrajectories.plot(traj, ylims=(0, 5)) isa Figure
+end
+
+@testitem "LaTeX strings" default_imports=false begin
+    using CairoMakie, NamedTrajectories, Test
+    # weird names
+    traj = NamedTrajectory((α_β_2=rand(2, 5), y_1_2=rand(1,5)), controls=:y_1_2, timestep=1.0)
+    @test NamedTrajectories.plot(traj, use_latex=false) isa Figure
+end
+
+
+end

--- a/src/plotting.jl
+++ b/src/plotting.jl
@@ -2,19 +2,8 @@ module Plotting
 
 export plot
 
-import CairoMakie: plot
-
-using CairoMakie
-using LaTeXStrings
 using OrderedCollections
-using TestItems
-
-using ..StructNamedTrajectory
-using ..StructKnotPoint
-using ..MethodsNamedTrajectory
-using ..MethodsKnotPoint
-
-import ..StructNamedTrajectory: NamedTrajectory
+using NamedTrajectories
 
 """
     plot(traj::NamedTrajectory, comps=traj.names; kwargs...)
@@ -46,402 +35,40 @@ Plot a `NamedTrajectory` using `CairoMakie`.
 ## other
 - `kwargs...`: keyword arguments passed to [`CairoMakie.series!`](https://docs.makie.org/stable/reference/plots/series/).
 """
-function plot(
-    traj::NamedTrajectory,
-    comps::Union{Symbol, Vector{Symbol}, Tuple{Vararg{Symbol}}} = traj.names;
-
-    # ---------------------------------------------------------------------------
-    # component specification keyword arguments
-    # ---------------------------------------------------------------------------
-
-    ignored_labels::Union{Symbol, Vector{Symbol}, Tuple{Vararg{Symbol}}}=(),
-    ignore_timestep::Bool=true,
-    merge_components::Bool=false,
-    use_latex::Bool=true,
-
-    # ---------------------------------------------------------------------------
-    # transformation keyword arguments
-    # ---------------------------------------------------------------------------
-
-    # transformations
-    transformations::OrderedDict{Symbol, <:Union{Function, Vector}} =
-        OrderedDict{Symbol, Union{Function, Vector{Function}}}(),
-
-    # labels for transformed components
-    transformation_labels::Union{
-        Nothing,
-        OrderedDict{
-            Symbol,
-            <:Union{
-                Nothing,
-                String,
-                Vector{<:Union{Nothing, <:AbstractString}}
-            }
-        }
-    } = OrderedDict{Symbol, Union{Nothing, Vector{Nothing}}}(name => f isa Vector ? fill(nothing, length(f)) : nothing for (name, f) ∈ transformations),
-
-    # whether or not to include labels for transformed components
-    include_transformation_labels::Union{
-        Bool,
-        Vector{<:Union{Bool, <:AbstractVector{Bool}}}
-    } = false,
-
-    # titles for transformations
-    transformation_titles::Union{
-        Nothing,
-        OrderedDict{Symbol, <:Union{<:AbstractString, <:AbstractVector{<:AbstractString}}}
-    } = nothing,
-
-    # ---------------------------------------------------------------------------
-    # style keyword arguments
-    # ---------------------------------------------------------------------------
-
-    fig_size::Tuple{Int, Int}=(1200, 800),
-    titlesize::Int=25,
-    markersize=5,
-    series_color::Symbol=:glasbey_bw_minc_20_n256,
-    xlims::Union{Nothing, Tuple{Real, Real}}=nothing,
-    ylims::Union{Nothing, NamedTuple, Tuple{Real, Real}}=nothing,
-
-    # ---------------------------------------------------------------------------
-    # CairoMakie.series! keyword arguments
-    # ---------------------------------------------------------------------------
-    kwargs...
-)
-    # set up parse function
-    parse = use_latex ? latexstring : string
-
-    # convert single symbol to vector: comps
-    if comps isa Symbol
-        comps = [comps]
-    end
-
-    # if transformations is only a bool, convert to vector of bools
-    if include_transformation_labels isa Bool
-        include_transformation_labels = fill(
-            include_transformation_labels,
-            length(transformations)
-        )
-    end
-
-    @assert length(include_transformation_labels) == length(transformations)
-
-    include_transformation_labels = Any[include_transformation_labels...]
-
-    for (i, (b, f)) ∈ enumerate(zip(
-        include_transformation_labels,
-        values(transformations)
-    ))
-        if f isa Function
-            @assert b isa Bool
-        else
-            if b isa Bool
-                include_transformation_labels[i] = fill(b, length(f))
-            else
-                @assert length(b) == length(f)
-            end
-        end
-    end
-
-    # convert single symbol to iterable: ignored labels
-    if ignored_labels isa Symbol
-        ignored_labels = Symbol[ignored_labels]
-    elseif ignored_labels isa Tuple
-        ignored_labels = Symbol[ignored_labels...]
-    end
-
-    @assert all([key ∈ keys(traj.components) for key ∈ comps])
-    @assert all([key ∈ keys(traj.components) for key ∈ keys(transformations)])
-
-    ts = get_times(traj)
-
-    # create figure
-    fig = Figure(size=fig_size)
-
-    # initialize axis count
-    ax_count = 0
-
-    # plot transformed components
-    for ((name, f), include_transformation_labels_k) ∈ zip(
-        transformations,
-        include_transformation_labels
-    )
-        if f isa Vector
-
-            @assert all([fⱼ isa Function for fⱼ in f])
-
-            for (j, fⱼ) in enumerate(f)
-
-                # data matrix for name component of trajectory
-                data = traj[name]
-
-                # apply transformation fⱼ to each column of data
-                transformed_data = mapslices(fⱼ, data; dims=1)
-
-                # ylims
-                if ylims isa NamedTuple
-                    if haskey(ylims, name)
-                        ylims_name = ylims[name]
-                    else
-                        ylims_name = (nothing, nothing)
-                    end
-                else
-                    ylims_name = ylims
-                end
-
-                if isnothing(transformation_titles)
-                    title = parse(name, "(t)", "\\text{ transformation } $j")
-                else
-                    title = transformation_titles[name][j]
-                end
-
-                # create axis for transformed data
-                ax = Axis(
-                    fig[ax_count + 1, 1];
-                    title=title,
-                    titlesize=titlesize,
-                    xlabel=L"t",
-                    limits =(xlims, ylims_name)
-                )
-
-                # plot transformed data
-                if include_transformation_labels_k[j]
-
-                    if isnothing(transformation_labels[name][j])
-                        labels = string.(1:size(transformed_data, 2))
-                    else
-                        labels = [
-                            parse(transformation_labels[name][j], "_{$i}")
-                                for i = 1:size(transformed_data, 2)
-                        ]
-                    end
-
-                    series!(
-                        ax,
-                        ts,
-                        transformed_data;
-                        color=series_color,
-                        markersize=markersize,
-                        labels=labels
-                    )
-                    # create legend
-                    Legend(fig[ax_count + 1, 2], ax)
-                else
-                    series!(
-                        ax,
-                        ts,
-                        transformed_data;
-                        color=series_color,
-                        markersize=markersize
-                    )
-                end
-
-                # increment axis count
-                ax_count += 1
-            end
-        else
-
-            # data matrix for name componenent of trajectory
-            data = traj[name]
-
-            # apply transformation f to each column of data
-            transformed_data = mapslices(f, data; dims=1)
-
-            if isnothing(transformation_titles)
-                title = parse(name, "(t)", "\\text{ transformation}")
-            else
-                if isnothing(transformation_titles[name])
-                    title = parse(name, "(t)", "\\text{ transformation}")
-                else
-                    title = transformation_titles[name]
-                end
-            end
-
-            # ylims
-            if ylims isa NamedTuple
-                if haskey(ylims, name)
-                    ylims_name = ylims[name]
-                else
-                    ylims_name = (nothing, nothing)
-                end
-            else
-                ylims_name = ylims
-            end
-
-            if isnothing(transformation_titles)
-                title = parse(name, "(t)", "\\text{ transformation}")
-            else
-                title = transformation_titles[name]
-            end
-
-            # create axis for transformed data
-            ax = Axis(
-                fig[ax_count + 1, :];
-                title=title,
-                titlesize=titlesize,
-                xlabel=L"t",
-                limits=(xlims, ylims_name)
-            )
-
-            # plot transformed data
-            if include_transformation_labels_k
-
-                if isnothing(transformation_labels[name])
-                    labels = [
-                        parse(name, "_{$i}")
-                            for i = 1:size(transformed_data, 2)
-                    ]
-                else
-                    labels = [
-                        parse(transformation_labels[name], "_{$i}")
-                            for i = 1:size(transformed_data, 2)
-                    ]
-                end
-
-                series!(
-                    ax,
-                    ts,
-                    transformed_data;
-                    color=series_color,
-                    markersize=markersize,
-                    labels=labels
-                )
-                # create legend
-                Legend(fig[ax_count + 1, 2], ax)
-            else
-                series!(
-                    ax,
-                    ts,
-                    transformed_data;
-                    color=series_color,
-                    markersize=markersize,
-                    kwargs...
-                )
-            end
-
-            # increment axis count
-            ax_count += 1
-        end
-    end
-    
-    # create shared axis for data
-    if merge_components
-        # ylims
-        if ylims isa NamedTuple
-            throw(ArgumentError("plot_ylims must be a tuple if merge_components is true"))
-        end
-        ax = Axis(
-            fig[ax_count + 1, 1];
-            title=parse("Trajectory"),
-            titlesize=titlesize,
-            xlabel=L"t",
-            limits=(xlims, ylims)
-        )
-    end
-
-    # plot normal components
-    for (i, name) in enumerate(comps)
-
-        if traj.timestep isa Symbol && name == traj.timestep && ignore_timestep
-            continue
-        end
-
-        # data matrix for name componenent of trajectory
-        data = traj[name]
-        
-        # create axis for data
-        if !merge_components
-            # ylims
-            if ylims isa NamedTuple
-                if haskey(ylims, name)
-                    ylims_name = ylims[name]
-                else
-                    ylims_name = (nothing, nothing)
-                end
-            else
-                ylims_name = ylims
-            end
-            
-            ax = Axis(
-                fig[ax_count + 1, 1];
-                title=parse(name, "(t)"),
-                titlesize=titlesize,
-                xlabel=L"t",
-                limits =(xlims, ylims_name)
-            )
-        end
-
-        # create labels if name is not in ignored_labels
-        if name ∈ ignored_labels
-            labels = nothing
-        else
-            labels = [parse(name, "_{$i}") for i = 1:size(data, 1)]
-        end
-
-        # plot data
-        series!(
-            ax,
-            ts,
-            data;
-            color=series_color,
-            markersize=markersize,
-            labels=labels,
-            kwargs...
-        )
-
-        # create legend
-        if name ∉ ignored_labels
-            Legend(fig[ax_count + 1, 2], ax)
-        end
-
-        # increment axis count
-        if !merge_components
-            ax_count += 1
-        end
-    end
-
-    return fig
-end
-
-function plot(path::String, traj::NamedTrajectory, comps=traj.names; kwargs...)
-    if !isdir(dirname(path))
-        mkdir(dirname(path))
-    end
-    save(path, plot(traj, comps; kwargs...))
-end
+function plot end
 
 # =========================================================================== #
 
-@testitem "save plotting" begin
-    plot_path = joinpath(@__DIR__, "test.pdf")
+# @testitem "save plotting" begin
+#     plot_path = joinpath(@__DIR__, "test.pdf")
 
-    traj = rand(NamedTrajectory, 5)
+#     traj = rand(NamedTrajectory, 5)
 
-    plot(plot_path, traj)
+#     plot(plot_path, traj)
 
-    @test isfile(plot_path)
+#     @test isfile(plot_path)
 
-    rm(plot_path)
-end
+#     rm(plot_path)
+# end
 
-@testitem "xlim and ylim" begin
-    using CairoMakie 
-    include("../test/test_utils.jl")
+# @testitem "xlim and ylim" begin
+#     using CairoMakie 
+#     include("../test/test_utils.jl")
     
-    # has x and y
-    traj = get_fixed_time_traj2()
-    @test plot(traj, xlims=(0, 5)) isa Figure
-    @test plot(traj, ylims=(x=(0, 5))) isa Figure
-    @test plot(traj, ylims=(x=(0, 5), y=(0, 5))) isa Figure
-    @test plot(traj, ylims=(0, 5)) isa Figure
-end
+#     # has x and y
+#     traj = get_fixed_time_traj2()
+#     @test plot(traj, xlims=(0, 5)) isa Figure
+#     @test plot(traj, ylims=(x=(0, 5))) isa Figure
+#     @test plot(traj, ylims=(x=(0, 5), y=(0, 5))) isa Figure
+#     @test plot(traj, ylims=(0, 5)) isa Figure
+# end
 
-@testitem "LaTeX strings" begin
-    using CairoMakie 
+# @testitem "LaTeX strings" begin
+#     using CairoMakie 
     
-    # weird names
-    traj = NamedTrajectory((α_β_2=rand(2, 5), y_1_2=rand(1,5)), controls=:y_1_2, timestep=1.0)
-    @test plot(traj, use_latex=false) isa Figure
-end
+#     # weird names
+#     traj = NamedTrajectory((α_β_2=rand(2, 5), y_1_2=rand(1,5)), controls=:y_1_2, timestep=1.0)
+#     @test plot(traj, use_latex=false) isa Figure
+# end
 
 end

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -22,18 +22,6 @@ function get_free_time_traj(;
     return NamedTrajectory(free_time_data; timestep=Δt, controls=:u, kwargs...)
 end
 
-function get_fixed_time_traj2(;
-    T::Int=5, 
-    Δt::Float64=0.1, 
-    x_dim::Int=3, 
-    y_dim=3, 
-    a_dim::Int=2,
-    kwargs...
-)
-    fixed_time_data = (x = rand(x_dim, T), y_dim = rand(y_dim, T), u = rand(a_dim, T))
-    return NamedTrajectory(fixed_time_data; timestep=Δt, controls=:u, kwargs...)
-end
-
 function named_trajectory_type_1(; free_time=false)
     # Hadamard gate, two dda controls (random), Δt = 0.2
     data = [


### PR DESCRIPTION
**IMPORTANT**

Current implementation means conflicting global symbols exported from Makie/MakieCore/CairoMakie - specifically "plot".

We must either:
a) change all namedtrajectories plot calls to use path `plot -> NamedTrajectories.plot`
b) change the symbol name in NamedTrajectories `plot -> nm_plot`
c) use extension package to register a recipe within Makie to continue to use their symbol `plot`